### PR TITLE
Fix world blacklist handling and make /wit reload apply config changes immediately

### DIFF
--- a/src/main/java/com/github/darksoulq/wit/WITListener.java
+++ b/src/main/java/com/github/darksoulq/wit/WITListener.java
@@ -20,12 +20,11 @@ import java.io.File;
 import java.util.*;
 import java.util.function.BiFunction;
 
-
 public class WITListener implements Listener {
 
     public static final File PREF_FOLDER = new File(WIT.instance().getDataFolder(), "cache/players");
     private static final List<UUID> PLAYERS = new ArrayList<>();
-    public static final List<World> DISABLED_WORLDS = new ArrayList<>();
+    public static final List<String> DISABLED_WORLDS = new ArrayList<>();
     private static final Map<Player, Info> LOOKING_AT = new HashMap<>();
     private static YamlConfiguration CONFIG = ConfigUtils.loadConfig();
     private static int ENTITY_DISTANCE = CONFIG.getInt("core.entitydistance", 25);
@@ -38,7 +37,8 @@ public class WITListener implements Listener {
         }
         for (UUID playerID : PLAYERS) {
             Player player = Bukkit.getPlayer(playerID);
-            if (player == null) continue;
+            if (player == null)
+                continue;
             WAILAManager.removeBar(player, getPlayerConfig(player).getString("type"));
         }
 
@@ -47,13 +47,16 @@ public class WITListener implements Listener {
             public void run() {
                 for (UUID playerID : PLAYERS) {
                     Player player = Bukkit.getPlayer(playerID);
-                    if (player == null) continue;
-                    if ("sneaking".equals(CONFIG.getString("core.mode", "normal")) && !player.isSneaking()) return;
+                    if (player == null)
+                        continue;
+                    if ("sneaking".equals(CONFIG.getString("core.mode", "normal")) && !player.isSneaking())
+                        return;
                     updateWAILA(player);
                 }
             }
         }.runTaskTimer(WIT.instance(), 0, CONFIG.getInt("core.update-delay", 5));
     }
+
     private void updateWAILA(Player player) {
         Block block = MathUtils.getLookingAtBlock(player, BLOCK_DISTANCE);
         Entity entity = MathUtils.isLookingAtEntity(player, ENTITY_DISTANCE);
@@ -63,7 +66,8 @@ public class WITListener implements Listener {
                     return;
                 }
             }
-            if (CONFIG.getBoolean("entities.enabled", true) && !ItemGroups.getBlacklistedEntities().contains(entity.getType())) {
+            if (CONFIG.getBoolean("entities.enabled", true)
+                    && !ItemGroups.getBlacklistedEntities().contains(entity.getType())) {
                 if (MinecraftCompat.handleEntity(entity, player)) {
                     return;
                 }
@@ -75,7 +79,8 @@ public class WITListener implements Listener {
                     return;
                 }
             }
-            if (CONFIG.getBoolean("blocks.enabled", true) && !ItemGroups.getBlacklistedBlocks().contains(block.getType())) {
+            if (CONFIG.getBoolean("blocks.enabled", true)
+                    && !ItemGroups.getBlacklistedBlocks().contains(block.getType())) {
                 if (MinecraftCompat.handleBlock(block, player)) {
                     return;
                 }
@@ -88,6 +93,7 @@ public class WITListener implements Listener {
             WAILAManager.removeBar(player, getPlayerConfig(player).getString("type"));
         }
     }
+
     public static void setup() {
         CONFIG = ConfigUtils.loadConfig();
         if (CONFIG.getString("core.mode", "normal").equalsIgnoreCase("hidden")) {
@@ -103,21 +109,27 @@ public class WITListener implements Listener {
     public static void removePlayer(Player player) {
         PLAYERS.remove(player.getUniqueId());
     }
+
     public static void addPlayer(Player player) {
         PLAYERS.add(player.getUniqueId());
     }
+
     public static File getPrefFolder() {
         return PREF_FOLDER;
     }
+
     public static YamlConfiguration getPlayerConfig(Player player) {
         return YamlConfiguration.loadConfiguration(new File(PREF_FOLDER + "/" + player.getName() + ".yml"));
     }
+
     public static boolean isHidden() {
         return IS_HIDDEN;
     }
+
     public static Info getLookingAt(Player player) {
         return LOOKING_AT.get(player);
     }
+
     public static void setLookingAt(Player player, Info value) {
         LOOKING_AT.put(player, value);
     }

--- a/src/main/java/com/github/darksoulq/wit/WITListener.java
+++ b/src/main/java/com/github/darksoulq/wit/WITListener.java
@@ -96,8 +96,11 @@ public class WITListener implements Listener {
 
     public static void setup() {
         CONFIG = ConfigUtils.loadConfig();
-        if (CONFIG.getString("core.mode", "normal").equalsIgnoreCase("hidden")) {
+        String mode = CONFIG.getString("core.mode", "normal");
+        if (mode.equalsIgnoreCase("hidden")) {
             IS_HIDDEN = true;
+        } else if (mode.equalsIgnoreCase("normal") || mode.equalsIgnoreCase("sneaking")) {
+            IS_HIDDEN = false;
         } else {
             IS_HIDDEN = false;
             WIT.instance().getLogger().warning("Invalid mode in config.yml, defaulting to normal");

--- a/src/main/java/com/github/darksoulq/wit/WITListener.java
+++ b/src/main/java/com/github/darksoulq/wit/WITListener.java
@@ -58,6 +58,9 @@ public class WITListener implements Listener {
     }
 
     private void updateWAILA(Player player) {
+        if (DISABLED_WORLDS.contains(player.getWorld().getName())) {
+            return;
+        }
         Block block = MathUtils.getLookingAtBlock(player, BLOCK_DISTANCE);
         Entity entity = MathUtils.isLookingAtEntity(player, ENTITY_DISTANCE);
         if (entity != null) {

--- a/src/main/java/com/github/darksoulq/wit/command/WCommands.java
+++ b/src/main/java/com/github/darksoulq/wit/command/WCommands.java
@@ -12,6 +12,7 @@ import com.github.darksoulq.wit.Handlers;
 import com.github.darksoulq.wit.Information;
 import com.github.darksoulq.wit.WITListener;
 import com.github.darksoulq.wit.api.API;
+import com.github.darksoulq.wit.compatibility.MinecraftCompat;
 import com.github.darksoulq.wit.display.WAILAManager;
 import com.github.darksoulq.wit.misc.ItemGroups;
 import net.kyori.adventure.text.Component;
@@ -80,6 +81,7 @@ public class WCommands {
 
     private static int reloadExecutor(CommandContext<CommandSourceStack> ctx) {
         WITListener.setup();
+        MinecraftCompat.setup();
         Information.reloadValuesFile();
         Handlers.setup();
         ItemGroups.reload();

--- a/src/main/java/com/github/darksoulq/wit/command/WCommands.java
+++ b/src/main/java/com/github/darksoulq/wit/command/WCommands.java
@@ -29,19 +29,16 @@ public class WCommands {
         return Commands.literal("wit")
                 .then(Commands.literal("toggle")
                         .requires(sender -> sender.getSender().hasPermission("wit.default"))
-                        .executes(WCommands::toggleExecutor)
-                )
+                        .executes(WCommands::toggleExecutor))
                 .then(Commands.literal("type")
                         .then(Commands.argument("type", StringArgumentType.string())
                                 .requires(sender -> sender.getSender().hasPermission("wit.default"))
                                 .suggests(WCommands::changeTypeSuggester)
-                                .executes(WCommands::changeTypeExecutor))
-                )
+                                .executes(WCommands::changeTypeExecutor)))
                 .then(Commands.literal("reload")
                         .requires(sender -> sender.getSender().hasPermission("wit.reload"))
                         .executes(WCommands::reloadExecutor));
     }
-
 
     private static int toggleExecutor(CommandContext<CommandSourceStack> ctx) {
         CommandSender sender = ctx.getSource().getSender();
@@ -76,7 +73,7 @@ public class WCommands {
     }
 
     private static CompletableFuture<Suggestions> changeTypeSuggester(final CommandContext<CommandSourceStack> ctx,
-                                                                      final SuggestionsBuilder builder) {
+            final SuggestionsBuilder builder) {
         WAILAManager.getDisplays().keySet().forEach(builder::suggest);
         return builder.buildFuture();
     }
@@ -143,7 +140,7 @@ public class WCommands {
             return;
         }
 
-        if (!WITListener.DISABLED_WORLDS.contains(player.getWorld())) {
+        if (!WITListener.DISABLED_WORLDS.contains(player.getWorld().getName())) {
             WITListener.addPlayer(player);
             WAILAManager.setBar(player, Component.text(""));
         }

--- a/src/main/java/com/github/darksoulq/wit/misc/ConfigUtils.java
+++ b/src/main/java/com/github/darksoulq/wit/misc/ConfigUtils.java
@@ -25,8 +25,10 @@ public class ConfigUtils {
         copyTemplate("config.yml", CONFIG_FILE);
         copyTemplate("values.yml", VALUES_FILE);
     }
+
     /**
-     * Copies a template file from the plugin's resources to disk if it doesn't exist already.
+     * Copies a template file from the plugin's resources to disk if it doesn't
+     * exist already.
      *
      * @param resourceName The name of the resource template file.
      * @param destination  The destination file on disk.
@@ -54,18 +56,18 @@ public class ConfigUtils {
         YamlConfiguration config = YamlConfiguration.loadConfiguration(CONFIG_FILE);
         WITListener.DISABLED_WORLDS.clear();
         config.getStringList("world-blacklist").forEach(wn -> {
-            World world = Bukkit.getWorld(wn);
-            if (world == null) return;
-            WITListener.DISABLED_WORLDS.add(world);
+            WITListener.DISABLED_WORLDS.add(wn);
         });
         return config;
     }
+
     public static YamlConfiguration loadValuesFIle() {
         return YamlConfiguration.loadConfiguration(VALUES_FILE);
     }
+
     public static String toProperCase(String enumName) {
         return Arrays.stream(enumName.split("_"))
-                .map(s -> s.substring(0,1).toUpperCase() + s.substring(1).toLowerCase())
+                .map(s -> s.substring(0, 1).toUpperCase() + s.substring(1).toLowerCase())
                 .collect(Collectors.joining(" "));
     }
 }

--- a/src/main/java/com/github/darksoulq/wit/misc/Events.java
+++ b/src/main/java/com/github/darksoulq/wit/misc/Events.java
@@ -30,7 +30,8 @@ public class Events implements Listener {
 
     @EventHandler
     public void onBlockBreakProgress(BlockBreakProgressUpdateEvent event) {
-        if (ItemGroups.getBlacklistedBlocks().contains(event.getBlock().getType())) return;
+        if (ItemGroups.getBlacklistedBlocks().contains(event.getBlock().getType()))
+            return;
         BREAK_PROGRESS.put(event.getBlock(), event.getProgress());
         if (event.getProgress() == 1f || event.getProgress() == 0f) {
             BREAK_PROGRESS.remove(event.getBlock());
@@ -39,18 +40,20 @@ public class Events implements Listener {
 
     @EventHandler
     public void onPlayerWorldChange(PlayerChangedWorldEvent event) {
-        if (DISABLED_WORLDS.contains(event.getPlayer().getWorld())) {
+        if (DISABLED_WORLDS.contains(event.getPlayer().getWorld().getName())) {
             WAILAManager.removeBar(event.getPlayer(), getPlayerConfig(event.getPlayer()).getString("type", "bossbar"));
             WITListener.removePlayer(event.getPlayer());
         } else {
             WITListener.addPlayer(event.getPlayer());
         }
     }
+
     @EventHandler
     public void onPlayerQuit(PlayerQuitEvent event) {
         WAILAManager.removeBar(event.getPlayer(), getPlayerConfig(event.getPlayer()).getString("type", "bossbar"));
         WITListener.removePlayer(event.getPlayer());
     }
+
     @EventHandler
     public void onPlayerJoin(PlayerJoinEvent event) {
         File playerFile = new File(PREF_FOLDER + "/" + event.getPlayer().getName() + ".yml");
@@ -59,7 +62,8 @@ public class Events implements Listener {
             try {
                 playerFile.createNewFile();
                 pconfig = YamlConfiguration.loadConfiguration(playerFile);
-                pconfig.set("disableWAILA", "disabled".equals(WITListener.getConfig().getString("core.default_state", "enabled")));
+                pconfig.set("disableWAILA",
+                        "disabled".equals(WITListener.getConfig().getString("core.default_state", "enabled")));
                 pconfig.set("type", "bossbar");
                 pconfig.save(playerFile);
             } catch (Exception e) {
@@ -69,7 +73,7 @@ public class Events implements Listener {
             pconfig = YamlConfiguration.loadConfiguration(playerFile);
         }
         boolean disableBossBar = pconfig.getBoolean("disableWAILA", false);
-        if (!disableBossBar && !DISABLED_WORLDS.contains(event.getPlayer().getWorld())) {
+        if (!disableBossBar && !DISABLED_WORLDS.contains(event.getPlayer().getWorld().getName())) {
             WITListener.addPlayer(event.getPlayer());
         }
     }


### PR DESCRIPTION
Fix two issues related to world blacklist and configuration reload.

Changes:
- Store world names instead of Bukkit World objects
- Prevent blacklist failure when worlds are not loaded during plugin startup
- Ensure /wit reload refreshes blacklist values

Result:
Configuration changes now apply immediately after running /wit reload.